### PR TITLE
Change Rust SDK link to something that's maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of Wooting related awesomeness!
 
 - [Analog Unreal Engine plugin](https://github.com/WootingKb/wooting-analog-unreal-plugin) Plugin for Unreal Engine to support the integration of Wooting Analog inputs
 - [Python Wooting RGB](https://github.com/xiamaz/python-wooting-rgb) Python wrapper for Wooting RGB SDK
-- [Rust Wooting SDK](https://github.com/davidtwco/rust-wooting-sdk) Rust wrapper for Wooting RGB SDK (and legacy Analog SDK)
+- [Rust Wooting RGB](https://github.com/ShayBox/Wooting-RGB) Rust wrapper for Wooting RGB SDK
 - [WootingAnalogSDK.NET](https://github.com/WootingKb/wooting-analog-wrappers) .NET Wrapper for the Wooting Analog SDK
 - [Wooting.JS](https://github.com/Mexican-Man/wooting-js) Lightweight Javascript(TS) library for reading analog input on the Web using WebHID!
 - [DeviceRGB - UE4](https://github.com/pramberg/DeviceRGB) Plugin for UE4 that lets you control RGB devices using materials and textures (With Wooting RGB SDK support)


### PR DESCRIPTION
The old one just barely supports the original Wooting Two.