### PR TITLE
Add Universal Analog Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ A collection of Wooting related awesomeness!
 
 ## Misc
 
+- [Universal Analog Plugin](https://github.com/calamity-inc/universal-analog-plugin) is a plugin for the Wooting Analog SDK that adds support for Razer keyboards
 - [Wooting Snake](https://github.com/TanTanDev/wooting_snake) Snake on wooting keyboards, written with Rust
 - [wootinstaller](https://github.com/Calslock/wootinstaller) Wootility auto-configurator and installer for Linux/Steam Deck


### PR DESCRIPTION
Not sure if this is the best place to put it, but I feel like it's good for people to know that their Razer analogue keyboards can also benefit from apps using the Wooting Analog SDK.